### PR TITLE
Add `kill_switch` parameter to `BatchTask`

### DIFF
--- a/src/prefecto/concurrency/__init__.py
+++ b/src/prefecto/concurrency/__init__.py
@@ -1,0 +1,7 @@
+from prefecto.concurrency.batch_task import BatchTask
+from prefecto.concurrency.kill_switch import (
+    KillSwitch,
+    AnyFailedSwitch,
+    CountSwitch,
+    RateSwitch,
+)

--- a/src/prefecto/concurrency/kill_switch.py
+++ b/src/prefecto/concurrency/kill_switch.py
@@ -1,0 +1,114 @@
+"""
+Kill switch logic classes for stopping the execution of a `BatchTask`.
+
+"""
+
+import abc
+
+from prefect.states import State
+
+
+class KillSwitchError(Exception):
+    """Error raised when a kill switch is activated."""
+
+    def __init__(self, message: str, ks: "KillSwitch"):
+        super().__init__(message)
+        self.ks = ks
+
+
+class KillSwitch(abc.ABC):
+    """Abstract base class for a kill switch."""
+
+    @abc.abstractmethod
+    def should_flip_switch(self, state: State) -> bool:
+        """Check if this state should flip the kill switch.
+
+        Returns:
+            `True` if the kill switch should be activated, `False` otherwise.
+
+        """
+
+    @abc.abstractmethod
+    def raise_if_triggered(self, state: State):
+        """Check a state and raise a `KillSwitchError` if the kill switch has been activated.
+
+        Raises:
+            KillSwitchError: If the kill switch has been activated.
+
+        """
+
+
+class AnyFailedSwitch(KillSwitch):
+    """A kill switch that activates if any tasks failed."""
+
+    def should_flip_switch(self, state: State) -> bool:
+        """Check if the state is failed or crashed."""
+        return state.is_failed() or state.is_crashed()
+
+    def raise_if_triggered(self, state: State):
+        """Raise a `KillSwitchError` if the state is failed or crashed."""
+        if self.should_flip_switch(state):
+            raise KillSwitchError("Failed task detected.", self)
+
+
+class CountSwitch(KillSwitch):
+    """A kill switch that activates after a certain number of tasks fail.
+
+    Args:
+        count (int): The number of states after which to activate the kill switch.
+
+    """
+
+    def __init__(self, max_count: int):
+        self.max_count = max_count
+        self._current_count = 0
+
+    def should_flip_switch(self, state: State) -> bool:
+        """Increment the count if the state is failed or crashed and return if the count exceeds
+        the maximum.
+        """
+        if state.is_failed() or state.is_crashed():
+            self._current_count += 1
+        return self._current_count >= self.max_count
+
+    def raise_if_triggered(self, state: State):
+        """Raise a `KillSwitchError` if the count exceeds the maximum."""
+        if self.should_flip_switch(state):
+            raise KillSwitchError(f"{self.max_count} failed tasks detected.", self)
+
+
+class RateSwitch(KillSwitch):
+    """A kill switch that activates after the failure rate exceeds a certain threshold.
+    Requires a minimum number of states to sample.
+
+    Args:
+        min_sample (int): The minimum number of states to sample.
+        max_fail_rate (float): The maximum frequency of failed states.
+
+    """
+
+    def __init__(self, min_sample: int, max_fail_rate: float):
+        self.min_sample = min_sample
+        self.max_fail_rate = max_fail_rate
+        self._current_count = 0
+        self._failed_count = 0
+
+    def should_flip_switch(self, state: State) -> bool:
+        """Increment the count if the state is failed or crashed and return if the failure rate
+        exceeds the maximum tolerable rate.
+        """
+        self._current_count += 1
+        if state.is_failed() or state.is_crashed():
+            self._failed_count += 1
+        return (
+            self._current_count >= self.min_sample
+            and self._failed_count / self._current_count >= self.max_fail_rate
+        )
+
+    def raise_if_triggered(self, state: State):
+        """Raise a `KillSwitchError` if the failure rate exceeds the maximum tolerable rate."""
+        if self.should_flip_switch(state):
+            raise KillSwitchError(
+                f"Failure rate exceeded {self.max_fail_rate} after {self.min_sample} samples.",
+                self,
+            )

--- a/tests/concurrency/test_batch_task.py
+++ b/tests/concurrency/test_batch_task.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import pytest
 from prefect import flow, task, unmapped
 
-from prefecto.concurrency import BatchTask
+from prefecto.concurrency.batch_task import BatchTask
 
 
 @task
@@ -77,3 +77,35 @@ class TestBatchTask:
 
         result = test()
         assert result == expectation
+
+    def test_map_with_kill_switch(self, harness):
+        """Test `BatchTask.map` with a kill switch."""
+        from prefecto.concurrency.kill_switch import CountSwitch, KillSwitchError
+
+        @flow
+        def test() -> list[int]:
+            """Test flow."""
+            bt = BatchTask(add, 3, CountSwitch(2))
+            bt.map([1, 2, 3, 4, 5, 6, 7, 8, 9], ["x", 1, 1, "y", 1, 1, 1, 1, 1])
+
+        with pytest.raises(KillSwitchError) as exc:
+            test()
+            assert isinstance(exc.value.ks, CountSwitch)
+            assert exc.value.ks._current_count == 2
+            assert exc.value.ks._max_count == 2
+
+    def test_map_with_kill_switch_within_batch(self, harness):
+        """Test `BatchTask.map` with a kill switch."""
+        from prefecto.concurrency.kill_switch import CountSwitch, KillSwitchError
+
+        @flow
+        def test() -> list[int]:
+            """Test flow."""
+            bt = BatchTask(add, 4, CountSwitch(2))
+            bt.map([1, 2, 3, 4, 5], ["x", 1, "y", 1, 1])
+
+        with pytest.raises(KillSwitchError) as exc:
+            test()
+            assert isinstance(exc.value.ks, CountSwitch)
+            assert exc.value.ks._current_count == 2
+            assert exc.value.ks._max_count == 2

--- a/tests/concurrency/test_kill_switch.py
+++ b/tests/concurrency/test_kill_switch.py
@@ -1,0 +1,33 @@
+import pytest
+from prefect import states
+
+from prefecto.concurrency.kill_switch import (
+    AnyFailedSwitch,
+    CountSwitch,
+    KillSwitchError,
+    RateSwitch,
+)
+
+
+@pytest.mark.asyncio
+async def test_any_kill_switch():
+    with pytest.raises(KillSwitchError):
+        AnyFailedSwitch().raise_if_triggered(states.Failed())
+
+
+@pytest.mark.asyncio
+async def test_count_kill_switch():
+    ks = CountSwitch(2)
+    ks.raise_if_triggered(states.Failed())
+    ks.raise_if_triggered(states.Completed())
+    with pytest.raises(KillSwitchError):
+        ks.raise_if_triggered(states.Failed())
+
+
+@pytest.mark.asyncio
+async def test_rate_kill_switch():
+    ks = RateSwitch(3, 0.5)
+    ks.raise_if_triggered(states.Completed())
+    ks.raise_if_triggered(states.Failed())
+    with pytest.raises(KillSwitchError):
+        ks.raise_if_triggered(states.Crashed())


### PR DESCRIPTION
Closes #26 

Created a `kill_switch` mechanism to let `BatchTask` quit before running all tasks. it is useful for cases where the number of tasks to map is very high and failures may suggest the entire flow ought to cancel.

```python
from prefect import flow, task
from prefecto.concurrency import BatchTask, CountSwitch

@task
def my_task(a, b):
    return a + b

@flow
def my_flow():
    bt = BatchTask(my_task, size=2, kill_switch=CountSwitch(3))
    # Should stop on the third batch, when 5 + "c" raises a ValueError
    bt.map(a=[1, 2, 3, 4, 5, 6, 7, 8], b=["a", 1, 2, "b", "c", 3, 4, 5])
```
